### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "mime": "^2.4.4",
     "mongoose": "^5.5.14",
     "multer": "^1.4.1",
-    "npm": "^6.9.0",
     "passport": "^0.4.0",
     "passport-google-oauth": "^2.0.0",
     "react-bootstrap": "^1.0.0-beta.9",


### PR DESCRIPTION

Hello igormuba!

It seems like you have npm as one of your (dev-) dependency in review-salad.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
